### PR TITLE
fix(cockroach): retry on transient SQLSTATE errors

### DIFF
--- a/connection_instrumented.go
+++ b/connection_instrumented.go
@@ -5,13 +5,12 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/jackc/pgx/v5/stdlib"
 	"strings"
 	"sync"
 
 	mysqld "github.com/go-sql-driver/mysql"
 	"github.com/gobuffalo/pop/v6/logging"
+	"github.com/jackc/pgx/v5/pgxpool"
 	pgx "github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
 	"github.com/luna-duclos/instrumentedsql"
@@ -95,20 +94,28 @@ func openPotentiallyInstrumentedConnection(ctx context.Context, c dialect, dsn s
 
 	// If "pool_min_conns" is set in the DSN, it means that we use the pgx pool feature flag.
 	if strings.Contains(dsn, "pool_min_conns=") {
+		var (
+			pool *pgxpool.Pool
+			err  error
+		)
 		// But of course only on Cockroach and PostgreSQL.
 		switch CanonicalDialect(c.DefaultDriver()) {
 		case nameCockroach:
-			fallthrough
-		case namePostgreSQL:
-			pool, err := pgxpool.New(ctx, dsn)
+			// CockroachDB has additional SQLSTATEs that indicate connections can be retried.
+			pool, err = connectWithRetry(ctx, dsn, c.Details())
 			if err != nil {
 				return nil, nil, err
 			}
 
-			// We don't need to configure the database/sql connection pool because pgxpool already does that.
-			// Reference: https://github.com/jackc/pgx/discussions/2222#discussioncomment-11772064
-			return sqlx.NewDb(stdlib.OpenDBFromPool(pool), dialect), pool, nil
+		case namePostgreSQL:
+			pool, err = pgxpool.New(ctx, dsn)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
+		// We don't need to configure the database/sql connection pool because pgxpool already does that.
+		// Reference: https://github.com/jackc/pgx/discussions/2222#discussioncomment-11772064
+		return sqlx.NewDb(pgx.OpenDBFromPool(pool), dialect), pool, nil
 	}
 
 	con, err := sql.Open(driverName, dsn)

--- a/connection_instrumented_test.go
+++ b/connection_instrumented_test.go
@@ -99,3 +99,30 @@ func (s *SQLiteSuite) Test_Instrumentation() {
 func (s *CockroachSuite) Test_Instrumentation() {
 	testInstrumentedDriver(&s.Suite)
 }
+
+func (s *CockroachSuite) Test_ConnectWithRetryLogic() {
+	r := s.Require()
+
+	// save and restore env var
+	orig := os.Getenv("SODA_DIALECT")
+	defer os.Setenv("SODA_DIALECT", orig)
+
+	_ = os.Setenv("SODA_DIALECT", "cockroach")
+
+	deets := *Connections["cockroach"].Dialect.Details()
+	deets.Options["retry_limit"] = "2"
+	deets.Options["retry_sleep"] = "1ms"
+
+	// fail with invalid port
+	badDSN := "postgresql://root@localhost:59999/bogus?pool_min_conns=1&sslmode=disable"
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	start := time.Now()
+	_, _, err := openPotentiallyInstrumentedConnection(ctx, Connections["cockroach"].Dialect, badDSN)
+	duration := time.Since(start)
+
+	r.Error(err)
+	r.GreaterOrEqual(duration, 2*time.Millisecond, "expected at least 2ms of backoff retries")
+}

--- a/dialect_cockroach.go
+++ b/dialect_cockroach.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gobuffalo/fizz"
 	"github.com/gobuffalo/fizz/translators"
@@ -21,6 +24,8 @@ import (
 	"github.com/gobuffalo/pop/v6/internal/defaults"
 	"github.com/gobuffalo/pop/v6/logging"
 	"github.com/gofrs/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // Import PostgreSQL driver
 	"github.com/jmoiron/sqlx"
 )
@@ -40,6 +45,16 @@ func init() {
 }
 
 var _ dialect = &cockroach{}
+
+var retryableSQLStates = map[string]struct{}{
+	// Class 57 — Operator Intervention
+	"57000": {}, "57014": {}, "57P01": {}, "57P02": {},
+	"57P03": {}, "57P04": {}, "57P05": {},
+
+	// Class 08 — Connection Exception
+	"08000": {}, "08003": {}, "08006": {}, "08001": {},
+	"08004": {}, "08007": {}, "08P01": {},
+}
 
 // ServerInfo holds informational data about connected database server.
 type cockroachInfo struct {
@@ -398,4 +413,39 @@ func (p *cockroach) tablesQuery() string {
 		tableQuery = selectTablesQueryCockroachV1
 	}
 	return tableQuery
+}
+
+// isRetryableError checks if error is retryable.
+func isRetryableError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		_, ok := retryableSQLStates[pgErr.SQLState()]
+		return ok
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+}
+
+// connectWithRetry wraps pgxpool.New with retry logic.
+func connectWithRetry(ctx context.Context, dsn string, cd *ConnectionDetails) (*pgxpool.Pool, error) {
+	var lastErr error
+	for attempt := 0; attempt <= cd.RetryLimit(); attempt++ {
+		pool, err := pgxpool.New(ctx, dsn)
+		if err == nil {
+			if pingErr := pool.Ping(ctx); pingErr == nil {
+				return pool, nil
+			} else {
+				err = pingErr
+			}
+		}
+
+		if !isRetryableError(err) {
+			return nil, err
+		}
+
+		backoff := cd.RetrySleep() * time.Duration(math.Pow(2, float64(attempt)))
+		log(logging.Debug, "Retrying pgxpool.New in %v (attempt %d): %v", backoff, attempt+1, err)
+		time.Sleep(backoff)
+		lastErr = err
+	}
+	return nil, fmt.Errorf("connectWithRetry: failed after retries: %w", lastErr)
 }


### PR DESCRIPTION
Adds retry handling for CockroachDB connections in pgxpool based on `SQLSTATE` classes 08 (connection exceptions) and 57 (operator intervention). This applies only when the dialect is 'cockroach', using existing retry_limit and retry_sleep options in ConnectionDetails.

Implements guidance provided by CockroachDB support to improve resilience in Hydra/Kratos deployments during transient failures.

Ref: https://github.com/viragtripathi/cockroach-collections/blob/main/scripts/cockroach-go-with-retry/main.go