### PR TITLE
fix(sqlite): preserve SQLite URI params through finalizer

### DIFF
--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -368,9 +368,18 @@ var sqliteInternalKeys = map[string]bool{
 }
 
 // moderncSQLiteParams is the complete set of DSN query parameters recognised
-// by modernc.org/sqlite. Any key not in this set will be warned and stripped.
-// Source: modernc.org/sqlite@v1.47.0/sqlite.go applyQueryParams() and
-// modernc.org/sqlite@v1.47.0/conn.go newConn().
+// by modernc.org/sqlite or by SQLite itself via SQLITE_OPEN_URI. Any key not
+// in this set will be warned and stripped.
+//
+// Go driver params (modernc.org/sqlite@v1.48.0/sqlite.go applyQueryParams()
+// and conn.go newConn()):
+//   - vfs, _pragma, _time_format, _txlock, _time_integer_format, _inttotime,
+//     _texttotime
+//
+// SQLite URI params (https://sqlite.org/uri.html) — processed by SQLite
+// itself when the DSN starts with "file:" and SQLITE_OPEN_URI is set, which
+// modernc.org/sqlite enables unconditionally:
+//   - mode, cache, psow, nolock, immutable
 var moderncSQLiteParams = map[string]bool{
 	"vfs":                  true, // VFS name
 	"_pragma":              true, // PRAGMA name(value); repeatable
@@ -379,6 +388,11 @@ var moderncSQLiteParams = map[string]bool{
 	"_time_integer_format": true, // integer time repr: unix/unix_milli/unix_micro/unix_nano
 	"_inttotime":           true, // convert integer columns to time.Time
 	"_texttotime":          true, // affect ColumnTypeScanType for TEXT date columns
+	"mode":                 true, // SQLite URI: ro | rw | rwc | memory
+	"cache":                true, // SQLite URI: shared | private
+	"psow":                 true, // SQLite URI: powersafe overwrite
+	"nolock":               true, // SQLite URI: disable locking
+	"immutable":            true, // SQLite URI: read-only, no change check
 }
 
 func finalizerSQLite(cd *ConnectionDetails) {

--- a/dialect_sqlite_test.go
+++ b/dialect_sqlite_test.go
@@ -581,12 +581,9 @@ func Test_ConnectionDetails_Finalize_SQLite_URIParams(t *testing.T) {
 // Regression test for the bug where finalizerSQLite stripped SQLite URI
 // params, causing in-memory DSNs to silently fall back to disk files.
 func Test_ConnectionDetails_Finalize_SQLite_MemoryDSNStaysInMemory(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	const name = "memtest"
+	dbPath := filepath.Join(t.TempDir(), "memtest")
 	cd := &ConnectionDetails{
-		URL: fmt.Sprintf("sqlite3://file:%s?mode=memory&cache=shared", name),
+		URL: fmt.Sprintf("sqlite3://file:%s?mode=memory&cache=shared", dbPath),
 	}
 	require.NoError(t, cd.Finalize())
 
@@ -596,9 +593,9 @@ func Test_ConnectionDetails_Finalize_SQLite_MemoryDSNStaysInMemory(t *testing.T)
 	_, err = db.Exec("CREATE TABLE t(x INT); INSERT INTO t VALUES (1)")
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(dir, name))
+	_, err = os.Stat(dbPath)
 	require.True(t, os.IsNotExist(err),
-		"mode=memory DSN must not create an on-disk file at %q", name)
+		"mode=memory DSN must not create an on-disk file at %q", dbPath)
 }
 
 // Test_ConnectionDetails_Finalize_SQLite_DirectPragma verifies that

--- a/dialect_sqlite_test.go
+++ b/dialect_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -544,6 +545,60 @@ func Test_ConnectionDetails_Finalize_SQLite_Programmatic(t *testing.T) {
 	require.Equal(t, "WAL", cd.Options["_journal_mode"])
 	require.Equal(t, "10000", cd.Options["_busy_timeout"])
 	require.Equal(t, "1", cd.Options["_fk"])
+}
+
+// Test_ConnectionDetails_Finalize_SQLite_URIParams verifies that SQLite URI
+// query parameters (mode, cache, psow, nolock, immutable) are preserved in
+// RawOptions. These are processed by SQLite itself when SQLITE_OPEN_URI is
+// set — modernc.org/sqlite passes the URI through unchanged — and stripping
+// them breaks `mode=memory` in-memory databases by falling back to disk files
+// named after the URI path.
+func Test_ConnectionDetails_Finalize_SQLite_URIParams(t *testing.T) {
+	for _, tc := range []struct {
+		key, value string
+	}{
+		{"mode", "memory"},
+		{"cache", "shared"},
+		{"psow", "0"},
+		{"nolock", "1"},
+		{"immutable", "1"},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			cd := &ConnectionDetails{
+				URL: fmt.Sprintf("sqlite3://file:x?%s=%s", tc.key, tc.value),
+			}
+			require.NoError(t, cd.Finalize())
+			q, err := url.ParseQuery(cd.RawOptions)
+			require.NoError(t, err)
+			require.Equal(t, tc.value, q.Get(tc.key),
+				"SQLite URI param %q=%q must survive finalizer", tc.key, tc.value)
+		})
+	}
+}
+
+// Test_ConnectionDetails_Finalize_SQLite_MemoryDSNStaysInMemory opens a DSN
+// with mode=memory&cache=shared and asserts no file is created on disk.
+// Regression test for the bug where finalizerSQLite stripped SQLite URI
+// params, causing in-memory DSNs to silently fall back to disk files.
+func Test_ConnectionDetails_Finalize_SQLite_MemoryDSNStaysInMemory(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	const name = "memtest"
+	cd := &ConnectionDetails{
+		URL: fmt.Sprintf("sqlite3://file:%s?mode=memory&cache=shared", name),
+	}
+	require.NoError(t, cd.Finalize())
+
+	db, err := sql.Open("sqlite3", cd.Database+"?"+cd.RawOptions)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec("CREATE TABLE t(x INT); INSERT INTO t VALUES (1)")
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, name))
+	require.True(t, os.IsNotExist(err),
+		"mode=memory DSN must not create an on-disk file at %q", name)
 }
 
 // Test_ConnectionDetails_Finalize_SQLite_DirectPragma verifies that


### PR DESCRIPTION
## Summary

- Extend the `moderncSQLiteParams` allow-list in `finalizerSQLite` to include SQLite's own URI parameters (`mode`, `cache`, `psow`, `nolock`, `immutable`) so they are no longer stripped from the DSN before it reaches `modernc.org/sqlite`.
- Add red/green regression tests covering both the param-preservation invariant and the user-visible effect (a `mode=memory` DSN must not create an on-disk file).

## Why

`finalizerSQLite` removed every DSN query key not in `moderncSQLiteParams`, with a comment claiming that set was the "complete list of params recognised by modernc.org/sqlite". That's true for Go-driver params (`_pragma`, `_time_format`, …), but SQLite itself *also* reads a set of URI parameters (`mode`, `cache`, `psow`, `nolock`, `immutable`) from the DSN when `SQLITE_OPEN_URI` is set — which `modernc.org/sqlite` enables unconditionally (see `modernc.org/sqlite@v1.48.0/conn.go:64`).

Because of the missing entries, a DSN like:

```
file:<name>?mode=memory&cache=shared
```

…had `mode=memory` and `cache=shared` stripped before reaching `sqlite3_open_v2`. SQLite then treated the request as a normal file open and silently **created an on-disk file named `<name>`** in the working directory, instead of a pure in-memory database.

### How we noticed

Stray 12-char randomly-named SQLite files kept appearing in `hydra/hydra-oss/` after each test run in `ory-corp/cloud`. Hydra's memory-mode provider builds exactly this DSN:

```go
// hydra-oss/driver/config/provider.go:315
fmt.Sprintf("sqlite://file:%s?_fk=true&mode=memory&cache=shared&_busy_timeout=100000&_time_format=sqlite", randName)
```

Tracing the DSN through `ParseConnectionOptions` → `pop.NewConnection` → `finalizerSQLite` showed `mode` and `cache` being deleted with a warning (`SQLite DSN param "mode" is not supported by modernc.org/sqlite and will be ignored`). The resulting DSN reaching modernc was `file:<name>?_pragma=…`, no in-memory hint, so SQLite happily created the file on disk.

Any downstream service using `DSN=memory` (Hydra, Kratos, Keto, Oathkeeper) was affected — each process start leaks another SQLite file into the cwd.

## Test plan

- [x] New unit test `Test_ConnectionDetails_Finalize_SQLite_URIParams` — table-driven, asserts each of `mode`, `cache`, `psow`, `nolock`, `immutable` survives `Finalize()`.
- [x] New integration test `Test_ConnectionDetails_Finalize_SQLite_MemoryDSNStaysInMemory` — opens a DSN with `mode=memory&cache=shared`, writes data, and asserts no file was created on disk.
- [x] Both tests fail against \`main\` (verified red), pass with this fix (verified green).
- [x] Full `go test -tags sqlite .` passes (no existing test regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional SQLite URI parameters: mode, cache, psow, nolock, immutable.
  * Documentation updated to clarify which SQLite URI parameters are preserved and how unknown keys are handled.

* **Bug Fixes**
  * Ensures URI query parameters are retained so in-memory SQLite connections behave as expected (avoids unintended on-disk databases).

* **Tests**
  * Added regression tests validating preservation of SQLite URI parameters and in-memory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->