### PR TITLE
fix: treat pgx "conn closed" as sql.ErrTxDone

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -176,7 +176,7 @@ func (c *Connection) Transaction(fn func(tx *Connection) error) error {
 				// Therefore, the right thing to do is return the original error instead, as the sql.ErrTxDone is just a symptom.
 				return err
 			}
-			if strings.Contains(dberr.Error(), "conn closed") {
+			if dberr != nil && dberr.Error() == "conn closed" {
 				// see https://github.com/jackc/pgx/issues/2551
 				return err
 			}

--- a/connection.go
+++ b/connection.go
@@ -176,6 +176,10 @@ func (c *Connection) Transaction(fn func(tx *Connection) error) error {
 				// Therefore, the right thing to do is return the original error instead, as the sql.ErrTxDone is just a symptom.
 				return err
 			}
+			if strings.Contains(dberr.Error(), "conn closed") {
+				// see https://github.com/jackc/pgx/issues/2551
+				return err
+			}
 		} else {
 			txlog(logging.SQL, cn, "END Transaction ---")
 			dberr = cn.TX.Commit()


### PR DESCRIPTION
This fixes an annoying flake in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed database transactions when connections are unexpectedly closed. The system now returns the original error instead of a secondary rollback error, providing clearer error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->